### PR TITLE
When client gets winner, restart button does not return client interface to voting

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -8,7 +8,7 @@ function setConnectionState(state, connectionState, connected) {
 }
 
 function setState(state, newState) {
-  return state.merge(newState);
+  return state.remove('winner').merge(newState);
 }
 
 function vote(state, entry) {


### PR DESCRIPTION
When all entries are voted and server return winner to clients, then a vote manager can not reset client interfaces via the reset button.
Because `merge` does not remove `winner` state from client state. 
So before merge I add removing `winner`, and if it pass via server newState it correctly apply in client state.

PS. Thank you for this brilliant tutorial !! Very clearly and simple sentence writing, it is very comfortable to understand for the non-native english readers!
