### PR TITLE
Use double quotes for test script. Fixes #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js 'test/**/*.@(js|jsx)'"
+    "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js \"test/**/*.@(js|jsx)\""
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
To fix #3. Mocha files mask needs double quotes.
