### PR TITLE
Use react-addons-test-utils instead of react/addons.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "css-loader": "^0.17.0",
     "jsdom": "^6.5.1",
     "mocha": "^2.3.0",
+    "react-addons-test-utils": "^0.14.3",
     "react-hot-loader": "^1.3.0",
     "style-loader": "^0.12.3",
     "webpack": "^1.12.0",

--- a/test/components/ConnectionState_spec.js
+++ b/test/components/ConnectionState_spec.js
@@ -1,9 +1,10 @@
-import React from 'react/addons';
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
 import {expect} from 'chai';
 import {ConnectionState} from '../../src/components/ConnectionState';
 
 const {renderIntoDocument, findRenderedDOMComponentWithTag}
-  = React.addons.TestUtils;
+  = ReactTestUtils;
 
 describe('ConnectionState', () => {
 

--- a/test/components/Results_spec.js
+++ b/test/components/Results_spec.js
@@ -1,10 +1,11 @@
-import React from 'react/addons';
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
 import {List, Map} from 'immutable';
 import {Results} from '../../src/components/Results';
 import {expect} from 'chai';
 
 const {renderIntoDocument, scryRenderedDOMComponentsWithClass, Simulate}
-  = React.addons.TestUtils;
+  = ReactTestUtils;
 
 describe('Results', () => {
 

--- a/test/components/Voting_spec.jsx
+++ b/test/components/Voting_spec.jsx
@@ -1,10 +1,11 @@
-import React from 'react/addons';
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
 import {List} from 'immutable';
 import {Voting} from '../../src/components/Voting';
 import {expect} from 'chai';
 
 const {renderIntoDocument, scryRenderedDOMComponentsWithTag, Simulate}
-  = React.addons.TestUtils;
+  = ReactTestUtils;
 
 describe('Voting', () => {
 


### PR DESCRIPTION
Gets rid of the following warning:

```
Warning: require('react/addons') is deprecated. Access using require('react-addons-{addon}') instead.
```
