### PR TITLE
Use ReactDOM.findDOMNode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "css-loader": "^0.17.0",
     "jsdom": "^6.5.1",
     "mocha": "^2.3.0",
+    "react-dom": "^0.14.3",
     "react-hot-loader": "^1.3.0",
     "style-loader": "^0.12.3",
     "webpack": "^1.12.0",

--- a/test/components/Results_spec.js
+++ b/test/components/Results_spec.js
@@ -1,3 +1,4 @@
+import ReactDOM from 'react-dom';
 import React from 'react/addons';
 import {List, Map} from 'immutable';
 import {Results} from '../../src/components/Results';
@@ -34,7 +35,7 @@ describe('Results', () => {
                tally={Map()}
                next={next}/>
     );
-    Simulate.click(React.findDOMNode(component.refs.next));
+    Simulate.click(ReactDOM.findDOMNode(component.refs.next));
 
     expect(nextInvoked).to.equal(true);
   });
@@ -47,7 +48,7 @@ describe('Results', () => {
                tally={Map()}
                restart={() => restartInvoked = true}/>
     );
-    Simulate.click(React.findDOMNode(component.refs.restart));
+    Simulate.click(ReactDOM.findDOMNode(component.refs.restart));
 
     expect(restartInvoked).to.equal(true);
   });
@@ -58,7 +59,7 @@ describe('Results', () => {
                pair={["Trainspotting", "28 Days Later"]}
                tally={Map()} />
     );
-    const winner = React.findDOMNode(component.refs.winner);
+    const winner = ReactDOM.findDOMNode(component.refs.winner);
     expect(winner).to.be.ok;
     expect(winner.textContent).to.contain('Trainspotting');
   });

--- a/test/components/Voting_spec.jsx
+++ b/test/components/Voting_spec.jsx
@@ -1,3 +1,4 @@
+import ReactDOM from 'react-dom';
 import React from 'react/addons';
 import {List} from 'immutable';
 import {Voting} from '../../src/components/Voting';
@@ -63,7 +64,7 @@ describe('Voting', () => {
     const buttons = scryRenderedDOMComponentsWithTag(component, 'button');
     expect(buttons.length).to.equal(0);
 
-    const winner = React.findDOMNode(component.refs.winner);
+    const winner = ReactDOM.findDOMNode(component.refs.winner);
     expect(winner).to.be.ok;
     expect(winner.textContent).to.contain('Trainspotting');
   });


### PR DESCRIPTION
Gets rid of the following warning:

```
Warning: React.findDOMNode is deprecated. Please use ReactDOM.findDOMNode from require('react-dom') instead.
```
