### PR TITLE
Fix setProps warning.

### DIFF
--- a/test/components/Voting_spec.jsx
+++ b/test/components/Voting_spec.jsx
@@ -1,3 +1,4 @@
+import ReactDOM from 'react-dom';
 import React from 'react/addons';
 import {List} from 'immutable';
 import {Voting} from '../../src/components/Voting';
@@ -70,30 +71,40 @@ describe('Voting', () => {
 
   it('renders as a pure component', () => {
     const pair = ['Trainspotting', '28 Days Later'];
-    const component = renderIntoDocument(
-      <Voting pair={pair} />
+    const div = document.createElement('div');
+    const component = ReactDOM.render(
+      <Voting pair={pair} />,
+      div
     );
 
     let firstButton = scryRenderedDOMComponentsWithTag(component, 'button')[0];
     expect(firstButton.textContent).to.equal('Trainspotting');
 
     pair[0] = 'Sunshine';
-    component.setProps({pair: pair});
+    ReactDOM.render(
+      <Voting pair={pair} />,
+      div
+    );
     firstButton = scryRenderedDOMComponentsWithTag(component, 'button')[0];
     expect(firstButton.textContent).to.equal('Trainspotting');
   });
 
   it('does update DOM when prop changes', () => {
     const pair = List.of('Trainspotting', '28 Days Later');
-    const component = renderIntoDocument(
-      <Voting pair={pair} />
+    const div = document.createElement('div');
+    const component = ReactDOM.render(
+      <Voting pair={pair} />,
+      div
     );
 
     let firstButton = scryRenderedDOMComponentsWithTag(component, 'button')[0];
     expect(firstButton.textContent).to.equal('Trainspotting');
 
     const newPair = pair.set(0, 'Sunshine');
-    component.setProps({pair: newPair});
+    ReactDOM.render(
+      <Voting pair={newPair} />,
+      div
+    );
     firstButton = scryRenderedDOMComponentsWithTag(component, 'button')[0];
     expect(firstButton.textContent).to.equal('Sunshine');
   });


### PR DESCRIPTION
Gets rid of the following warning:

```
Warning: setProps(...) and replaceProps(...) are deprecated. Instead, call render again at the top level.
```

The changes are based on the `ReactTestUtils.renderIntoDocument` [internals](https://github.com/facebook/react/blob/master/src/test/ReactTestUtils.js#L79) - we're just re-rendering the component with the new props, into the existing `div`.
